### PR TITLE
:bug: Raise addon csr threshoud to 11

### DIFF
--- a/pkg/registration/spoke/addon/registration_controller.go
+++ b/pkg/registration/spoke/addon/registration_controller.go
@@ -33,7 +33,7 @@ const (
 	indexByAddon = "indexByAddon"
 
 	// TODO(qiujian16) expose it if necessary in the future.
-	addonCSRThreshold = 10
+	addonCSRThreshold = 15
 )
 
 // addOnRegistrationController monitors ManagedClusterAddOns on hub and starts addOn registration


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

https://issues.redhat.com/browse/ACM-11947 

In 2.11. We add the OU in registratonConfiguration of cluster-proxy-addon: https://github.com/open-cluster-management-io/cluster-proxy/pull/183

But in the upgrade case, it will trigger the klusterlet-agent(2.10) stop and start clientCertificateController many times and create a lot of CSRs:

```
I0602 17:31:08.704725       1 base_controller.go:172] Shutting down ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer ...
I0602 17:31:08.704778       1 base_controller.go:114] Shutting down worker of ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer controller ...
I0602 17:31:08.704790       1 base_controller.go:104] All ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer workers have been terminated
I0602 17:31:08.784076       1 base_controller.go:67] Waiting for caches to sync for ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer
I0602 17:31:08.985512       1 base_controller.go:73] Caches are synced for ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer 
I0602 17:31:08.985614       1 base_controller.go:110] Starting #1 worker of ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer controller ...
I0602 17:31:08.996511       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"open-cluster-management-agent", Name:"klusterlet-agent", UID:"f312e9e9-9cef-4df2-ad48-299e4b6251d3", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NoValidCertificateFound' No valid client certificate for ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer is found. Bootstrap is required
I0602 17:31:09.011564       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"open-cluster-management-agent", Name:"klusterlet-agent", UID:"f312e9e9-9cef-4df2-ad48-299e4b6251d3", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'CSRCreated' A csr "addon-local-cluster-cluster-proxy-4k95n" is created
I0602 17:31:09.101409       1 base_controller.go:172] Shutting down ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer ...
I0602 17:31:09.101536       1 base_controller.go:114] Shutting down worker of ClientCertController@addon:cluster-proxy:signer:open-cluster-management.io/proxy-agent-signer controller ...
```

We need to make  klusterlet-agent(2.11) to have a higher addonCSRThreshold so that after klusterlet-agent(2.11) start, it won't pending on the condition: `Stop creating csr since there are too many csr created already on hub` 

---

The PR on registration_controller to fix the loop csr creations is also WIP.