### PR TITLE
🐛 Regenerate the hub kubeconfig secret if the cluster name of the current context changes

### DIFF
--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -61,7 +61,7 @@ func TestComplete(t *testing.T) {
 			secret: testinghelpers.NewHubKubeconfigSecret(
 				componentNamespace, "hub-kubeconfig-secret", "",
 				testinghelpers.NewTestCert("system:open-cluster-management:cluster2:agent2", 60*time.Second), map[string][]byte{
-					"kubeconfig":   testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					"kubeconfig":   testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 					"cluster-name": []byte("cluster3"),
 					"agent-name":   []byte("agent3"),
 				}),

--- a/pkg/registration/clientcert/certificate.go
+++ b/pkg/registration/clientcert/certificate.go
@@ -146,16 +146,18 @@ func getCertValidityPeriod(secret *corev1.Secret) (*time.Time, *time.Time, error
 }
 
 // BuildKubeconfig builds a kubeconfig based on a rest config template with a cert/key pair
-func BuildKubeconfig(server string, caData []byte, proxyURL, clientCertPath, clientKeyPath string) clientcmdapi.Config {
+func BuildKubeconfig(clusterName, server string, caData []byte,
+	proxyURL, clientCertPath, clientKeyPath string) clientcmdapi.Config {
 	// Build kubeconfig.
 	kubeconfig := clientcmdapi.Config{
 		// Define a cluster stanza based on the bootstrap kubeconfig.
-		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
-			Server:                   server,
-			InsecureSkipTLSVerify:    false,
-			CertificateAuthorityData: caData,
-			ProxyURL:                 proxyURL,
-		}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                   server,
+				InsecureSkipTLSVerify:    false,
+				CertificateAuthorityData: caData,
+				ProxyURL:                 proxyURL,
+			}},
 		// Define auth based on the obtained client cert.
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
 			ClientCertificate: clientCertPath,
@@ -163,7 +165,7 @@ func BuildKubeconfig(server string, caData []byte, proxyURL, clientCertPath, cli
 		}},
 		// Define a context that connects the auth info and cluster, and set it as the default
 		Contexts: map[string]*clientcmdapi.Context{"default-context": {
-			Cluster:   "default-cluster",
+			Cluster:   clusterName,
 			AuthInfo:  "default-auth",
 			Namespace: "configuration",
 		}},

--- a/pkg/registration/clientcert/certificate_test.go
+++ b/pkg/registration/clientcert/certificate_test.go
@@ -79,35 +79,35 @@ func TestHasValidHubKubeconfig(t *testing.T) {
 		{
 			name: "no key",
 			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{
-				KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+				KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 			}),
 		},
 		{
 			name: "no cert",
 			secret: testinghelpers.NewHubKubeconfigSecret(
 				testNamespace, testSecretName, "", &testinghelpers.TestCert{Key: []byte("key")}, map[string][]byte{
-					KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 		},
 		{
 			name: "bad cert",
 			secret: testinghelpers.NewHubKubeconfigSecret(
 				testNamespace, testSecretName, "", &testinghelpers.TestCert{Key: []byte("key"), Cert: []byte("bad cert")}, map[string][]byte{
-					KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 		},
 		{
 			name: "expired cert",
 			secret: testinghelpers.NewHubKubeconfigSecret(
 				testNamespace, testSecretName, "", testinghelpers.NewTestCert("test", -60*time.Second), map[string][]byte{
-					KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 		},
 		{
 			name: "invalid common name",
 			secret: testinghelpers.NewHubKubeconfigSecret(
 				testNamespace, testSecretName, "", testinghelpers.NewTestCert("test", 60*time.Second), map[string][]byte{
-					KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 			subject: &pkix.Name{
 				CommonName: "wrong-common-name",
@@ -116,7 +116,7 @@ func TestHasValidHubKubeconfig(t *testing.T) {
 		{
 			name: "valid kubeconfig",
 			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", testinghelpers.NewTestCert("test", 60*time.Second), map[string][]byte{
-				KubeconfigFile: testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+				KubeconfigFile: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 			}),
 			subject: &pkix.Name{
 				CommonName: "test",
@@ -269,7 +269,8 @@ func TestBuildKubeconfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			kubeconfig := BuildKubeconfig(c.server, c.caData, c.proxyURL, c.clientCertFile, c.clientKeyFile)
+			kubeconfig := BuildKubeconfig("default-cluster",
+				c.server, c.caData, c.proxyURL, c.clientCertFile, c.clientKeyFile)
 			currentContext, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]
 			if !ok {
 				t.Errorf("current context %q not found: %v", kubeconfig.CurrentContext, kubeconfig)

--- a/pkg/registration/clientcert/controller_test.go
+++ b/pkg/registration/clientcert/controller_test.go
@@ -101,7 +101,7 @@ func TestSync(t *testing.T) {
 				testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", testinghelpers.NewTestCert(commonName, 10000*time.Second), map[string][]byte{
 					ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
 					AgentNameFile:   []byte(testAgentName),
-					KubeconfigFile:  testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile:  testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 			},
 			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
@@ -116,7 +116,7 @@ func TestSync(t *testing.T) {
 				testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", testinghelpers.NewTestCert(commonName, -3*time.Second), map[string][]byte{
 					ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
 					AgentNameFile:   []byte(testAgentName),
-					KubeconfigFile:  testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					KubeconfigFile:  testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				}),
 			},
 			keyDataExpected: true,

--- a/pkg/registration/helpers/testing/testinghelpers.go
+++ b/pkg/registration/helpers/testing/testinghelpers.go
@@ -389,7 +389,7 @@ func NewApprovedV1beta1CSR(holder CSRHolder) *certv1beta1.CertificateSigningRequ
 	return csr
 }
 
-func NewKubeconfig(server, proxyURL string, caData, key, cert []byte) []byte {
+func NewKubeconfig(clusterName, server, proxyURL string, caData, key, cert []byte) []byte {
 	var clientKey, clientCertificate string
 	var clientKeyData, clientCertificateData []byte
 	if key != nil {
@@ -404,11 +404,12 @@ func NewKubeconfig(server, proxyURL string, caData, key, cert []byte) []byte {
 	}
 
 	kubeconfig := clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
-			Server:                   server,
-			ProxyURL:                 proxyURL,
-			CertificateAuthorityData: caData,
-		}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                   server,
+				ProxyURL:                 proxyURL,
+				CertificateAuthorityData: caData,
+			}},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
 			ClientCertificate:     clientCertificate,
 			ClientCertificateData: clientCertificateData,
@@ -416,7 +417,7 @@ func NewKubeconfig(server, proxyURL string, caData, key, cert []byte) []byte {
 			ClientKeyData:         clientKeyData,
 		}},
 		Contexts: map[string]*clientcmdapi.Context{"default-context": {
-			Cluster:   "default-cluster",
+			Cluster:   clusterName,
 			AuthInfo:  "default-auth",
 			Namespace: "default",
 		}},

--- a/pkg/registration/spoke/registration/secret_controller_test.go
+++ b/pkg/registration/spoke/registration/secret_controller_test.go
@@ -34,7 +34,7 @@ func TestDumpSecret(t *testing.T) {
 		}
 	}()
 
-	kubeConfigFile := testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil)
+	kubeConfigFile := testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil)
 
 	cases := []struct {
 		name          string
@@ -66,7 +66,7 @@ func TestDumpSecret(t *testing.T) {
 				map[string][]byte{
 					clientcert.ClusterNameFile: []byte("test"),
 					clientcert.AgentNameFile:   []byte("test"),
-					clientcert.KubeconfigFile:  testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					clientcert.KubeconfigFile:  testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				},
 			),
 			validateFiles: func(t *testing.T, hubKubeconfigDir string) {
@@ -91,7 +91,7 @@ func TestDumpSecret(t *testing.T) {
 				map[string][]byte{
 					clientcert.ClusterNameFile: []byte("test1"),
 					clientcert.AgentNameFile:   []byte("test"),
-					clientcert.KubeconfigFile:  testinghelpers.NewKubeconfig("https://127.0.0.1:6001", "", nil, nil, nil),
+					clientcert.KubeconfigFile:  testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
 				},
 			),
 			validateFiles: func(t *testing.T, hubKubeconfigDir string) {

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -234,11 +234,12 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 			managementKubeClient, 10*time.Minute, informers.WithNamespace(o.agentOptions.ComponentNamespace))
 
 		// create a kubeconfig with references to the key/cert files in the same secret
-		srever, proxyURL, caData, err := parseKubeconfig(o.registrationOption.BootstrapKubeconfig)
+		contextClusterName, server, proxyURL, caData, err := parseKubeconfig(o.registrationOption.BootstrapKubeconfig)
 		if err != nil {
 			return err
 		}
-		kubeconfig := clientcert.BuildKubeconfig(srever, caData, proxyURL, clientcert.TLSCertFile, clientcert.TLSKeyFile)
+		kubeconfig := clientcert.BuildKubeconfig(contextClusterName, server, caData,
+			proxyURL, clientcert.TLSCertFile, clientcert.TLSKeyFile)
 		kubeconfigData, err := clientcmd.Write(kubeconfig)
 		if err != nil {
 			return err
@@ -328,11 +329,12 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 	recorder.Event("HubClientConfigReady", "Client config for hub is ready.")
 
 	// create a kubeconfig with references to the key/cert files in the same secret
-	server, proxyURL, caData, err := parseKubeconfig(o.agentOptions.HubKubeconfigFile)
+	contextClusterName, server, proxyURL, caData, err := parseKubeconfig(o.agentOptions.HubKubeconfigFile)
 	if err != nil {
 		return err
 	}
-	kubeconfig := clientcert.BuildKubeconfig(server, caData, proxyURL, clientcert.TLSCertFile, clientcert.TLSKeyFile)
+	kubeconfig := clientcert.BuildKubeconfig(contextClusterName, server, caData,
+		proxyURL, clientcert.TLSCertFile, clientcert.TLSKeyFile)
 	kubeconfigData, err := clientcmd.Write(kubeconfig)
 	if err != nil {
 		return err
@@ -446,7 +448,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 //  4. Certificate in TLSCertFile is issued for the current cluster/agent;
 //  5. Certificate in TLSCertFile is not expired;
 //  6. Hub kubeconfig and bootstrap hub kubeconfig include the same server, proxyURL
-//     and CA bundle.
+//     CA bundle and cluster name.
 //
 // Normally, KubeconfigFile/TLSKeyFile/TLSCertFile will be created once the bootstrap process
 // completes. Changing the name of the cluster will make the existing hub kubeconfig invalid,
@@ -497,17 +499,28 @@ func (o *SpokeAgentConfig) HasValidHubClientConfig(ctx context.Context) (bool, e
 // 1. The hub server
 // 2. The proxy url
 // 3. The CA bundle
+// 4. The current context cluster name
 func (o *SpokeAgentConfig) isHubKubeconfigValid(ctx context.Context) (bool, error) {
-	bootstrapServer, bootstrapProxyURL, bootstrapCABndle, err := parseKubeconfig(o.registrationOption.BootstrapKubeconfig)
+	bootstrapCtxCluster, bootstrapServer, bootstrapProxyURL, bootstrapCABndle, err := parseKubeconfig(
+		o.registrationOption.BootstrapKubeconfig)
 	if err != nil {
 		return false, err
 	}
 
-	server, proxyURL, caBundle, err := parseKubeconfig(o.agentOptions.HubKubeconfigFile)
+	ctxCluster, server, proxyURL, caBundle, err := parseKubeconfig(o.agentOptions.HubKubeconfigFile)
 	switch {
 	case err != nil:
 		return false, err
-	case bootstrapServer != server, bootstrapProxyURL != proxyURL, !reflect.DeepEqual(bootstrapCABndle, caBundle):
+	case bootstrapServer != server,
+		bootstrapProxyURL != proxyURL,
+		!reflect.DeepEqual(bootstrapCABndle, caBundle),
+		// Here in addition to the server, proxyURL and CA bundle, we also need to compare the cluster name,
+		// because in some cases even the hub cluster API server serving certificate(kubeconfig ca bundle)
+		// is the same, but the signer certificate may be different(i.e the hub kubernetes cluster is rebuilt
+		// with a same serving certificate and url), so setting the cluster name in the bootstrap kubeconfig
+		// can help to distinguish the different clusters(signer certificate). And comparing the cluster name
+		// can help to avoid the situation that the hub kubeconfig is valid but not for the current cluster.
+		bootstrapCtxCluster != ctxCluster:
 		return false, nil
 	default:
 		return true, nil
@@ -529,21 +542,22 @@ func (o *SpokeAgentConfig) getSpokeClusterCABundle(kubeConfig *rest.Config) ([]b
 	return data, nil
 }
 
-func parseKubeconfig(filename string) (string, string, []byte, error) {
+func parseKubeconfig(filename string) (string, string, string, []byte, error) {
 	config, err := clientcmd.LoadFromFile(filename)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", "", nil, err
 	}
 
 	context, ok := config.Contexts[config.CurrentContext]
 	if !ok {
-		return "", "", nil, fmt.Errorf("kubeconfig %q does not contains context: %s", filename, config.CurrentContext)
+		return "", "", "", nil,
+			fmt.Errorf("kubeconfig %q does not contains context: %s", filename, config.CurrentContext)
 	}
 
 	cluster, ok := config.Clusters[context.Cluster]
 	if !ok {
-		return "", "", nil, fmt.Errorf("kubeconfig %q does not contains cluster: %s", filename, context.Cluster)
+		return "", "", "", nil, fmt.Errorf("kubeconfig %q does not contains cluster: %s", filename, context.Cluster)
 	}
 
-	return cluster.Server, cluster.ProxyURL, cluster.CertificateAuthorityData, nil
+	return context.Cluster, cluster.Server, cluster.ProxyURL, cluster.CertificateAuthorityData, nil
 }


### PR DESCRIPTION
cherrypick https://github.com/open-cluster-management-io/ocm/pull/473

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #https://issues.redhat.com/browse/ACM-11986