### PR TITLE
🐛 [mce-2.5] Only bind the agent role for the addon group (#157)

### DIFF
--- a/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrole.yaml
@@ -61,4 +61,4 @@ rules:
   verbs: ["approve", "sign"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings"]
-  verbs: ["get", "list", "watch", "create", "delete"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/pkg/addon/manager.go
+++ b/pkg/addon/manager.go
@@ -57,7 +57,7 @@ func RunManager(ctx context.Context, controllerContext *controllercmd.Controller
 	}
 
 	clusterInformerFactory := clusterinformers.NewSharedInformerFactory(hubClusterClient, 30*time.Minute)
-	addonInformerFactory := addoninformers.NewSharedInformerFactory(addonClient, 30*time.Minute)
+	addonInformerFactory := addoninformers.NewSharedInformerFactory(addonClient, 10*time.Minute)
 	workInformers := workv1informers.NewSharedInformerFactoryWithOptions(workClient, 10*time.Minute,
 		workv1informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
 			selector := &metav1.LabelSelector{
@@ -109,9 +109,7 @@ func RunControllerManagerWithInformers(
 
 	err = addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
 		cache.Indexers{
-			index.ManagedClusterAddonByNamespace: index.IndexManagedClusterAddonByNamespace, // addonDeployController
-			index.ManagedClusterAddonByName:      index.IndexManagedClusterAddonByName,      // addonConfigController
-			index.AddonByConfig:                  index.IndexAddonByConfig,                  // addonConfigController
+			index.ManagedClusterAddonByName: index.IndexManagedClusterAddonByName, // addonConfigurationController, addonManagementController
 		},
 	)
 	if err != nil {
@@ -121,8 +119,7 @@ func RunControllerManagerWithInformers(
 	// managementAddonConfigController
 	err = addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
 		cache.Indexers{
-			index.ClusterManagementAddonByConfig:    index.IndexClusterManagementAddonByConfig,
-			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement,
+			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement, // addonConfigurationController, addonManagementController
 		})
 	if err != nil {
 		return err

--- a/pkg/addon/templateagent/registration.go
+++ b/pkg/addon/templateagent/registration.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	openshiftcrypto "github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/pkg/errors"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -353,7 +353,7 @@ func (a *CRDTemplateAgentAddon) TemplatePermissionConfigFunc() agent.PermissionC
 					continue
 				}
 
-				err := a.createKubeClientPermissions(template.Name, kcrc, cluster, addon)
+				err := a.createKubeClientPermissions(kcrc, cluster, addon)
 				if err != nil {
 					return err
 				}
@@ -372,7 +372,6 @@ func (a *CRDTemplateAgentAddon) TemplatePermissionConfigFunc() agent.PermissionC
 }
 
 func (a *CRDTemplateAgentAddon) createKubeClientPermissions(
-	templateName string,
 	kcrc *addonapiv1alpha1.KubeClientRegistrationConfig,
 	cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn,
@@ -405,8 +404,7 @@ func (a *CRDTemplateAgentAddon) createKubeClientPermissions(
 				APIGroup: rbacv1.GroupName,
 				Name:     pc.CurrentCluster.ClusterRoleName,
 			}
-			err := a.createPermissionBinding(templateName,
-				cluster.Name, addon.Name, cluster.Name, roleRef, &owner)
+			err := a.createPermissionBinding(cluster.Name, addon.Name, cluster.Name, roleRef, &owner)
 			if err != nil {
 				return err
 			}
@@ -417,8 +415,8 @@ func (a *CRDTemplateAgentAddon) createKubeClientPermissions(
 
 			// set owner reference nil since the rolebinding has different namespace with the ManagedClusterAddon
 			// TODO: cleanup the rolebinding when the addon is deleted
-			err := a.createPermissionBinding(templateName,
-				cluster.Name, addon.Name, pc.SingleNamespace.Namespace, pc.SingleNamespace.RoleRef, nil)
+			err := a.createPermissionBinding(cluster.Name, addon.Name,
+				pc.SingleNamespace.Namespace, pc.SingleNamespace.RoleRef, nil)
 			if err != nil {
 				return err
 			}
@@ -427,16 +425,9 @@ func (a *CRDTemplateAgentAddon) createKubeClientPermissions(
 	return nil
 }
 
-func (a *CRDTemplateAgentAddon) createPermissionBinding(templateName, clusterName, addonName, namespace string,
+func (a *CRDTemplateAgentAddon) createPermissionBinding(clusterName, addonName, namespace string,
 	roleRef rbacv1.RoleRef, owner *metav1.OwnerReference) error {
-	// TODO: confirm the group
-	groups := agent.DefaultGroups(clusterName, addonName)
-	subject := []rbacv1.Subject{}
-	for _, group := range groups {
-		subject = append(subject, rbacv1.Subject{
-			Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: group,
-		})
-	}
+
 	binding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("open-cluster-management:%s:%s:agent",
@@ -447,27 +438,29 @@ func (a *CRDTemplateAgentAddon) createPermissionBinding(templateName, clusterNam
 				AddonTemplateLabelKey:          "",
 			},
 		},
-		RoleRef:  roleRef,
-		Subjects: subject,
+		RoleRef: roleRef,
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     rbacv1.GroupKind,
+				APIGroup: rbacv1.GroupName,
+				Name:     clusterAddonGroup(clusterName, addonName),
+			},
+		},
 	}
 	if owner != nil {
 		binding.OwnerReferences = []metav1.OwnerReference{*owner}
 	}
-	_, err := a.rolebindingLister.RoleBindings(namespace).Get(binding.Name)
-	switch {
-	case err == nil:
-		// TODO: update the rolebinding if it is not the same
-		a.logger.Info("Rolebinding already exists", "rolebindingName", binding.Name)
-		return nil
-	case apierrors.IsNotFound(err):
-		_, createErr := a.hubKubeClient.RbacV1().RoleBindings(namespace).Create(
-			context.TODO(), binding, metav1.CreateOptions{})
-		if createErr != nil && !apierrors.IsAlreadyExists(createErr) {
-			return createErr
-		}
-	case err != nil:
-		return err
-	}
 
-	return nil
+	_, modified, err := resourceapply.ApplyRoleBinding(context.TODO(),
+		a.hubKubeClient.RbacV1(), a.eventRecorder, binding)
+	if err == nil && modified {
+		a.logger.Info("Rolebinding for addon updated", "namespace", binding.Namespace, "name", binding.Name,
+			"clusterName", clusterName, "addonName", addonName)
+	}
+	return err
+}
+
+// clusterAddonGroup returns the group that represents the addon for the cluster
+func clusterAddonGroup(clusterName, addonName string) string {
+	return fmt.Sprintf("system:open-cluster-management:cluster:%s:addon:%s", clusterName, addonName)
 }

--- a/pkg/addon/templateagent/registration_test.go
+++ b/pkg/addon/templateagent/registration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	"github.com/stretchr/testify/assert"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificates "k8s.io/api/certificates/v1beta1"
@@ -601,6 +602,13 @@ func TestTemplatePermissionConfigFunc(t *testing.T) {
 				if len(rb.OwnerReferences) != 0 {
 					t.Errorf("expected rolebinding to have 0 owner reference, got %d", len(rb.OwnerReferences))
 				}
+				if len(rb.Subjects) != 1 {
+					t.Errorf("expected rolebinding to have 1 subject, got %d", len(rb.Subjects))
+				}
+				if rb.Subjects[0].Name != "system:open-cluster-management:cluster:cluster1:addon:addon1" {
+					t.Errorf("expected rolebinding subject name to be system:open-cluster-management:cluster:cluster1:addon:addon1, got %s",
+						rb.Subjects[0].Name)
+				}
 			},
 		},
 		{
@@ -656,7 +664,7 @@ func TestTemplatePermissionConfigFunc(t *testing.T) {
 		}
 
 		agent := NewCRDTemplateAgentAddon(ctx, c.addon.Name, c.agentName, hubKubeClient, addonClient, addonInformerFactory,
-			kubeInformers.Rbac().V1().RoleBindings().Lister(), nil)
+			kubeInformers.Rbac().V1().RoleBindings().Lister(), eventstesting.NewTestingEventRecorder(t))
 		f := agent.TemplatePermissionConfigFunc()
 		err := f(c.cluster, c.addon)
 		if err != c.expectedErr {

--- a/pkg/addon/templateagent/template_agent.go
+++ b/pkg/addon/templateagent/template_agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/valyala/fasttemplate"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,6 +60,7 @@ type CRDTemplateAgentAddon struct {
 	rolebindingLister   rbacv1lister.RoleBindingLister
 	addonName           string
 	agentName           string
+	eventRecorder       events.Recorder
 }
 
 // NewCRDTemplateAgentAddon creates a CRDTemplateAgentAddon instance
@@ -69,6 +71,7 @@ func NewCRDTemplateAgentAddon(
 	addonClient addonv1alpha1client.Interface,
 	addonInformers addoninformers.SharedInformerFactory,
 	rolebindingLister rbacv1lister.RoleBindingLister,
+	recorder events.Recorder,
 	getValuesFuncs ...addonfactory.GetValuesFunc,
 ) *CRDTemplateAgentAddon {
 
@@ -85,6 +88,7 @@ func NewCRDTemplateAgentAddon(
 		rolebindingLister:   rolebindingLister,
 		addonName:           addonName,
 		agentName:           agentName,
+		eventRecorder:       recorder,
 	}
 
 	return a

--- a/pkg/addon/templateagent/template_agent_test.go
+++ b/pkg/addon/templateagent/template_agent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -258,6 +259,7 @@ func TestAddonTemplateAgentManifests(t *testing.T) {
 			addonClient,
 			addonInformerFactory,
 			kubeInformers.Rbac().V1().RoleBindings().Lister(),
+			eventstesting.NewTestingEventRecorder(t),
 			addonfactory.GetAddOnDeploymentConfigValues(
 				addonfactory.NewAddOnDeploymentConfigGetter(addonClient),
 				addonfactory.ToAddOnCustomizedVariableValues,
@@ -374,6 +376,7 @@ func TestAgentInstallNamespace(t *testing.T) {
 			addonClient,
 			addonInformerFactory,
 			kubeInformers.Rbac().V1().RoleBindings().Lister(),
+			eventstesting.NewTestingEventRecorder(t),
 			addonfactory.GetAddOnDeploymentConfigValues(
 				addonfactory.NewAddOnDeploymentConfigGetter(addonClient),
 				addonfactory.ToAddOnCustomizedVariableValues,
@@ -538,6 +541,7 @@ func TestAgentManifestConfigs(t *testing.T) {
 			addonClient,
 			addonInformerFactory,
 			kubeInformers.Rbac().V1().RoleBindings().Lister(),
+			eventstesting.NewTestingEventRecorder(t),
 			addonfactory.GetAddOnDeploymentConfigValues(
 				addonfactory.NewAddOnDeploymentConfigGetter(addonClient),
 				addonfactory.ToAddOnCustomizedVariableValues,


### PR DESCRIPTION
* Only bind the agent role for the addon group



* Update addon rolebinding



* Start an addon informor for each addon



---------

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #https://issues.redhat.com/browse/ACM-16006