### PR TITLE
Agents stop update managedcluster status when clock is out of sync. 

### DIFF
--- a/pkg/registration/hub/lease/clocksynccontroller_test.go
+++ b/pkg/registration/hub/lease/clocksynccontroller_test.go
@@ -63,7 +63,7 @@ func TestClockSyncController(t *testing.T) {
 				testinghelpers.NewManagedCluster(),
 			},
 			leases: []runtime.Object{
-				testinghelpers.NewManagedClusterLease("managed-cluster-lease", now.Add(61*time.Second)),
+				testinghelpers.NewManagedClusterLease("managed-cluster-lease", now.Add(301*time.Second)),
 			},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
 				expected := metav1.Condition{


### PR DESCRIPTION
…#770)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Related PR: https://github.com/open-cluster-management-io/ocm/pull/770 