### PR TITLE
Agents stop update managedcluster status when clock is out of sync. (…

### DIFF
--- a/pkg/registration/hub/lease/clocksynccontroller_test.go
+++ b/pkg/registration/hub/lease/clocksynccontroller_test.go
@@ -63,7 +63,7 @@ func TestClockSyncController(t *testing.T) {
 				testinghelpers.NewManagedCluster(),
 			},
 			leases: []runtime.Object{
-				testinghelpers.NewManagedClusterLease("managed-cluster-lease", now.Add(61*time.Second)),
+				testinghelpers.NewManagedClusterLease("managed-cluster-lease", now.Add(301*time.Second)),
 			},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
 				expected := metav1.Condition{

--- a/pkg/registration/spoke/managedcluster/status_controller.go
+++ b/pkg/registration/spoke/managedcluster/status_controller.go
@@ -31,6 +31,7 @@ type managedClusterStatusController struct {
 	patcher          patcher.Patcher[*clusterv1.ManagedCluster, clusterv1.ManagedClusterSpec, clusterv1.ManagedClusterStatus]
 	hubClusterLister clusterv1listers.ManagedClusterLister
 	hubEventRecorder kevents.EventRecorder
+	recorder         events.Recorder
 }
 
 type statusReconcile interface {
@@ -97,6 +98,7 @@ func newManagedClusterStatusController(
 		},
 		hubClusterLister: hubClusterInformer.Lister(),
 		hubEventRecorder: hubEventRecorder,
+		recorder:         recorder,
 	}
 }
 
@@ -119,6 +121,13 @@ func (c *managedClusterStatusController) sync(ctx context.Context, syncCtx facto
 		if state == reconcileStop {
 			break
 		}
+	}
+
+	// check if managedcluster's clock is out of sync, if so, the agent will not be able to update the status of managed cluster.
+	outOfSynced := meta.IsStatusConditionFalse(newCluster.Status.Conditions, clusterv1.ManagedClusterConditionClockSynced)
+	if outOfSynced {
+		c.recorder.Eventf("ClockOutOfSync", "The managed cluster's clock is out of sync, the agent will not be able to update the status of managed cluster.")
+		return fmt.Errorf("the managed cluster's clock is out of sync, the agent will not be able to update the status of managed cluster.")
 	}
 
 	changed, err := c.patcher.PatchStatus(ctx, newCluster, newCluster.Status, cluster.Status)


### PR DESCRIPTION
…#770)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Related PR: https://github.com/open-cluster-management-io/ocm/pull/770