### PR TITLE
Add multiarch build support to Tekton configurations

### DIFF
--- a/.tekton/addon-manager-mce-29-pull-request.yaml
+++ b/.tekton/addon-manager-mce-29-pull-request.yaml
@@ -31,6 +31,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.addon.rhtap
     - name: path-context
@@ -117,6 +120,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/addon-manager-mce-29-push.yaml
+++ b/.tekton/addon-manager-mce-29-push.yaml
@@ -28,6 +28,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.addon.rhtap
     - name: path-context
@@ -114,6 +117,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/placement-mce-29-pull-request.yaml
+++ b/.tekton/placement-mce-29-pull-request.yaml
@@ -31,6 +31,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.placement.rhtap
     - name: path-context
@@ -117,6 +120,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/placement-mce-29-push.yaml
+++ b/.tekton/placement-mce-29-push.yaml
@@ -28,6 +28,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.placement.rhtap
     - name: path-context
@@ -114,6 +117,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/registration-mce-29-pull-request.yaml
+++ b/.tekton/registration-mce-29-pull-request.yaml
@@ -31,6 +31,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.registration.rhtap
     - name: path-context
@@ -117,6 +120,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/registration-mce-29-push.yaml
+++ b/.tekton/registration-mce-29-push.yaml
@@ -28,6 +28,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.registration.rhtap
     - name: path-context
@@ -114,6 +117,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/registration-operator-mce-29-pull-request.yaml
+++ b/.tekton/registration-operator-mce-29-pull-request.yaml
@@ -31,6 +31,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.registration-operator.rhtap
     - name: path-context
@@ -117,6 +120,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/registration-operator-mce-29-push.yaml
+++ b/.tekton/registration-operator-mce-29-push.yaml
@@ -28,6 +28,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.registration-operator.rhtap
     - name: path-context
@@ -114,6 +117,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/work-mce-29-pull-request.yaml
+++ b/.tekton/work-mce-29-pull-request.yaml
@@ -31,6 +31,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.work.rhtap
     - name: path-context
@@ -117,6 +120,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.

--- a/.tekton/work-mce-29-push.yaml
+++ b/.tekton/work-mce-29-push.yaml
@@ -28,6 +28,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.work.rhtap
     - name: path-context
@@ -114,6 +117,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description:
           List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.


### PR DESCRIPTION
This PR adds multiarch build support to all Tekton pipeline configurations. Updated build-platforms parameter to support linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x architectures. Applied changes to all Tekton pipeline files for both push and pull-request configurations. Enables multiarch container image builds for all components.