### PR TITLE
:seedling: Update .tekton files for mce-2.10/backplane-2.10

### DIFF
--- a/.tekton/addon-manager-mce-210-pull-request.yaml
+++ b/.tekton/addon-manager-mce-210-pull-request.yaml
@@ -4,18 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/ocm?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
-      event == "push" && target_branch
+      event == "pull_request" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: placement-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: addon-manager-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: placement-mce-29-on-push
+  name: addon-manager-mce-210-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,7 +25,9 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-29:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-210:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
     - name: build-platforms
       value:
         - linux/x86_64
@@ -32,7 +35,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.placement.rhtap
+      value: build/Dockerfile.addon.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -612,7 +615,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-placement-mce-29
+    serviceAccountName: build-pipeline-addon-manager-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/addon-manager-mce-210-push.yaml
+++ b/.tekton/addon-manager-mce-210-push.yaml
@@ -12,10 +12,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: registration-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: addon-manager-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: registration-mce-29-on-push
+  name: addon-manager-mce-210-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-29:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-210:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -32,7 +32,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.registration.rhtap
+      value: build/Dockerfile.addon.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -612,7 +612,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-registration-mce-29
+    serviceAccountName: build-pipeline-addon-manager-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/placement-mce-210-pull-request.yaml
+++ b/.tekton/placement-mce-210-pull-request.yaml
@@ -13,10 +13,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: registration-operator-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: placement-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: registration-operator-mce-29-on-pull-request
+  name: placement-mce-210-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-29:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-210:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: build-platforms
@@ -35,7 +35,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.registration-operator.rhtap
+      value: build/Dockerfile.placement.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -615,7 +615,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-registration-operator-mce-29
+    serviceAccountName: build-pipeline-placement-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/placement-mce-210-push.yaml
+++ b/.tekton/placement-mce-210-push.yaml
@@ -4,19 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/ocm?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
-      event == "pull_request" && target_branch
+      event == "push" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: registration-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: placement-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: registration-mce-29-on-pull-request
+  name: placement-mce-210-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -25,9 +24,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-29:on-pr-{{revision}}
-    - name: image-expires-after
-      value: 5d
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-210:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -35,7 +32,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.registration.rhtap
+      value: build/Dockerfile.placement.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -615,7 +612,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-registration-mce-29
+    serviceAccountName: build-pipeline-placement-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/registration-mce-210-pull-request.yaml
+++ b/.tekton/registration-mce-210-pull-request.yaml
@@ -4,18 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/ocm?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
-      event == "push" && target_branch
+      event == "pull_request" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: work-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: registration-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: work-mce-29-on-push
+  name: registration-mce-210-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,7 +25,9 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-29:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-210:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
     - name: build-platforms
       value:
         - linux/x86_64
@@ -32,7 +35,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.work.rhtap
+      value: build/Dockerfile.registration.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -612,7 +615,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-work-mce-29
+    serviceAccountName: build-pipeline-registration-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/registration-mce-210-push.yaml
+++ b/.tekton/registration-mce-210-push.yaml
@@ -12,10 +12,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: registration-operator-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: registration-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: registration-operator-mce-29-on-push
+  name: registration-mce-210-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-29:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-210:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -32,7 +32,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.registration-operator.rhtap
+      value: build/Dockerfile.registration.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -612,7 +612,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-registration-operator-mce-29
+    serviceAccountName: build-pipeline-registration-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/registration-operator-mce-210-pull-request.yaml
+++ b/.tekton/registration-operator-mce-210-pull-request.yaml
@@ -13,10 +13,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: placement-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: registration-operator-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: placement-mce-29-on-pull-request
+  name: registration-operator-mce-210-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-29:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-210:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: build-platforms
@@ -35,7 +35,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.placement.rhtap
+      value: build/Dockerfile.registration-operator.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -615,7 +615,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-placement-mce-29
+    serviceAccountName: build-pipeline-registration-operator-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/registration-operator-mce-210-push.yaml
+++ b/.tekton/registration-operator-mce-210-push.yaml
@@ -12,10 +12,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: addon-manager-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: registration-operator-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: addon-manager-mce-29-on-push
+  name: registration-operator-mce-210-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-29:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-210:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -32,7 +32,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.addon.rhtap
+      value: build/Dockerfile.registration-operator.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -612,7 +612,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-addon-manager-mce-29
+    serviceAccountName: build-pipeline-registration-operator-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/work-mce-210-pull-request.yaml
+++ b/.tekton/work-mce-210-pull-request.yaml
@@ -13,10 +13,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: addon-manager-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: work-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: addon-manager-mce-29-on-pull-request
+  name: work-mce-210-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-29:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-210:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: build-platforms
@@ -35,7 +35,7 @@ spec:
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile
-      value: build/Dockerfile.addon.rhtap
+      value: build/Dockerfile.work.rhtap
     - name: path-context
       value: .
   pipelineSpec:
@@ -615,7 +615,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-addon-manager-mce-29
+    serviceAccountName: build-pipeline-work-mce-210
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/work-mce-210-push.yaml
+++ b/.tekton/work-mce-210-push.yaml
@@ -4,19 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/ocm?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
-      event == "pull_request" && target_branch
+      event == "push" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-29
-    appstudio.openshift.io/component: work-mce-29
+    appstudio.openshift.io/application: release-mce-210
+    appstudio.openshift.io/component: work-mce-210
     pipelines.appstudio.openshift.io/type: build
-  name: work-mce-29-on-pull-request
+  name: work-mce-210-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -25,9 +24,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-29:on-pr-{{revision}}
-    - name: image-expires-after
-      value: 5d
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-210:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -615,7 +612,7 @@ spec:
       - name: netrc
         optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-work-mce-29
+    serviceAccountName: build-pipeline-work-mce-210
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
## Summary

This PR updates all .tekton files to support mce-2.10/backplane-2.10 branch by changing references from mce-2.9 to mce-2.10.

## Changes Made

- **Renamed all .tekton files** from `*-mce-29-*` pattern to `*-mce-210-*` pattern
- **Updated all content within files** to replace `mce-29` with `mce-210` including:
  - Application labels (`release-mce-29` → `release-mce-210`)
  - Component names (`addon-manager-mce-29` → `addon-manager-mce-210`)
  - Pipeline names (`addon-manager-mce-29-on-push` → `addon-manager-mce-210-on-push`)
  - Image URLs (`quay.io/.../addon-manager-mce-29:...` → `quay.io/.../addon-manager-mce-210:...`)
  - Service account names (`build-pipeline-addon-manager-mce-29` → `build-pipeline-addon-manager-mce-210`)

## Files Updated

- addon-manager-mce-29-pull-request.yaml → addon-manager-mce-210-pull-request.yaml
- addon-manager-mce-29-push.yaml → addon-manager-mce-210-push.yaml
- placement-mce-29-pull-request.yaml → placement-mce-210-pull-request.yaml
- placement-mce-29-push.yaml → placement-mce-210-push.yaml
- registration-mce-29-pull-request.yaml → registration-mce-210-pull-request.yaml
- registration-mce-29-push.yaml → registration-mce-210-push.yaml
- registration-operator-mce-29-pull-request.yaml → registration-operator-mce-210-pull-request.yaml
- registration-operator-mce-29-push.yaml → registration-operator-mce-210-push.yaml
- work-mce-29-pull-request.yaml → work-mce-210-pull-request.yaml
- work-mce-29-push.yaml → work-mce-210-push.yaml

## Testing

All files have been verified to contain the correct updated references and maintain proper YAML structure.

Signed-off-by: zhujian <jiazhu@redhat.com>