### PR TITLE
Refactor Dockerfile to use ARG for SOURCE_GIT_TAG instead of hardcoding the CI version

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -3,10 +3,12 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
-# hardcode the CI version to block konflux build issue (ACM-21721)
-# TODO: Pass the CI version from the top when triggering a build
-# ENV SOURCE_GIT_TAG=${CI_VERSION}
-ENV SOURCE_GIT_TAG=v2.9.1
+
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines/common_mce_2.9.yaml
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary
- Refactors Dockerfile to use ARG for SOURCE_GIT_TAG instead of hardcoding the CI version
- Improves maintainability and flexibility for version management

## Test plan
- [x] Verify Dockerfile builds successfully with new ARG approach
- [x] Confirm SOURCE_GIT_TAG can be overridden during build process
- [x] Test integration with existing CI/CD pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)