### PR TITLE
Add MCE_VERSION ARG and SOURCE_GIT_TAG ENV to registration-operator Dockerfile

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -2,6 +2,11 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines/common_mce_2.x.yaml 【这里2.x对应branch， main branch是2.10】
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary

This PR adds the MCE_VERSION build argument and SOURCE_GIT_TAG environment variable to the registration-operator Dockerfile in the backplane-2.6 branch.

## Changes

- Added `ARG MCE_VERSION` to accept the MCE version from the build pipeline
- Added `ENV SOURCE_GIT_TAG=${MCE_VERSION}` to set the source git tag environment variable
- Added `RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"` for logging purposes
- Added comments referencing the common MCE pipeline source

## Context

The MCE_VERSION comes from the common pipeline at:
https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines/common_mce_2.x.yaml

This enables proper version tracking and integration with the MCE build system for the backplane-2.6 branch.

## Testing

- [ ] Dockerfile builds successfully with the new ARG and ENV variables
- [ ] SOURCE_GIT_TAG is properly set when MCE_VERSION is provided