### PR TITLE
Add MCE_VERSION argument to registration-operator Dockerfile

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -2,6 +2,11 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary

This PR adds the MCE_VERSION argument and SOURCE_GIT_TAG environment variable to the registration-operator RHTAP Dockerfile.

## Changes
- Added ARG MCE_VERSION
- Added ENV SOURCE_GIT_TAG=${MCE_VERSION}
- Added RUN echo statement to log the SOURCE_GIT_TAG value
- Added comments referencing the common pipeline source

## Motivation

The MCE_VERSION comes from the common pipeline at https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines and this change enables proper version tracking in the container build process.