### PR TITLE
Add MCE_VERSION and SOURCE_GIT_TAG environment variables to registration-operator Dockerfile

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -2,6 +2,11 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary

Added MCE_VERSION build argument and SOURCE_GIT_TAG environment variable to the registration-operator RHTAP Dockerfile.

## Changes

- Added `ARG MCE_VERSION` to accept version parameter from build pipeline
- Added `ENV SOURCE_GIT_TAG=${MCE_VERSION}` to set the source tag environment variable
- Added `RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"` to display the tag during build
- Added descriptive comments explaining the MCE_VERSION source

## Context

The MCE_VERSION comes from the common pipeline at https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines. This change enables proper version tracking and build reproducibility for the registration-operator container.

## Testing

This change affects the container build process and should be validated by:
1. Building the container with the MCE_VERSION argument provided
2. Verifying the SOURCE_GIT_TAG environment variable is correctly set
3. Confirming the echo statement outputs the expected tag during build