### PR TITLE
Add MCE_VERSION support to registration-operator Dockerfile

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -2,6 +2,11 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary

This PR adds support for MCE_VERSION argument and SOURCE_GIT_TAG environment variable to the registration-operator Dockerfile.

## Changes

- Added `ARG MCE_VERSION` to accept version from konflux build pipeline
- Added `ENV SOURCE_GIT_TAG=${MCE_VERSION}` for build traceability
- Added `RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"` for verification
- Included reference comment pointing to the konflux build catalog pipeline

## Context

The MCE_VERSION comes from the common pipeline:
https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines

This enables better build tracking and version management in the CI/CD pipeline.

## Testing

The changes are additive and should not affect existing functionality. The new environment variable will be available for any processes that need build version information.