### PR TITLE
Add MCE_VERSION arg and SOURCE_GIT_TAG env to registration-operator Dockerfile

### DIFF
--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -2,6 +2,11 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS bui
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
+# MCE_VERSION comes from this common pipeline:
+# https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines
+ARG MCE_VERSION
+ENV SOURCE_GIT_TAG=${MCE_VERSION}
+RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
 RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 


### PR DESCRIPTION
## Summary

This PR adds MCE_VERSION argument and SOURCE_GIT_TAG environment variable to the build/Dockerfile.registration-operator.rhtap file.

## Changes

- Added `ARG MCE_VERSION` to accept MCE version parameter
- Added `ENV SOURCE_GIT_TAG=${MCE_VERSION}` to set the source git tag environment variable
- Added `RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"` for verification during build
- Added comments referencing the common pipeline source

## Context

The MCE_VERSION comes from the common pipeline: https://github.com/stolostron/konflux-build-catalog/blob/main/pipelines

These changes enable proper version tracking and build verification for the registration operator container.