### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for addon-manager-mce-29

### DIFF
--- a/build/Dockerfile.addon.rhtap
+++ b/build/Dockerfile.addon.rhtap
@@ -14,6 +14,7 @@ LABEL \
       io.k8s.description="addon-manager" \
       io.k8s.display-name="addon-manager" \
       com.redhat.component="multicluster-engine-addon-manager-container" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       io.openshift.tags="data,images"
 
 ENV USER_UID=10001


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
