### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for placement-mce-29

### DIFF
--- a/build/Dockerfile.placement.rhtap
+++ b/build/Dockerfile.placement.rhtap
@@ -14,7 +14,8 @@ LABEL \
       io.k8s.description="placement" \
       io.k8s.display-name="placement" \
       com.redhat.component="multicluster-engine-placement-container" \
-      io.openshift.tags="data,images"
+      io.openshift.tags="data,images" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"
 
 ENV USER_UID=10001
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
