### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for registration-mce-29

### DIFF
--- a/build/Dockerfile.registration.rhtap
+++ b/build/Dockerfile.registration.rhtap
@@ -15,6 +15,7 @@ LABEL \
       io.k8s.description="registration" \
       io.k8s.display-name="registration" \
       com.redhat.component="multicluster-engine-registration-container" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       io.openshift.tags="data,images"
 
 ENV USER_UID=10001


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
