### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for work-mce-29

### DIFF
--- a/build/Dockerfile.work.rhtap
+++ b/build/Dockerfile.work.rhtap
@@ -15,7 +15,8 @@ LABEL \
       io.k8s.description="work" \
       io.k8s.display-name="work" \
       com.redhat.component="multicluster-engine-work-container" \
-      io.openshift.tags="data,images"
+      io.openshift.tags="data,images" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"
 
 ENV USER_UID=10001
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
