### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.addon.rhtap
+++ b/build/Dockerfile.addon.rhtap
@@ -8,6 +8,7 @@ RUN GO_BUILD_PACKAGES=./cmd/addon make build --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/ocm" \
       name="multicluster-engine/addon-manager-rhel9" \
       summary="addon-manager" \
       description="addon-manager" \

--- a/build/Dockerfile.placement.rhtap
+++ b/build/Dockerfile.placement.rhtap
@@ -8,6 +8,7 @@ RUN GO_BUILD_PACKAGES=./cmd/placement make build --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/ocm" \
       name="multicluster-engine/placement-rhel9" \
       summary="placement" \
       description="placement" \

--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -13,6 +13,7 @@ RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-va
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/ocm" \
       name="multicluster-engine/registration-operator-rhel9" \
       summary="registration-operator" \
       description="registration-operator" \

--- a/build/Dockerfile.registration.rhtap
+++ b/build/Dockerfile.registration.rhtap
@@ -8,6 +8,7 @@ RUN GO_BUILD_PACKAGES=./cmd/registration make build --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/ocm" \
       name="multicluster-engine/registration-rhel9" \
       summary="registration" \
       description="registration" \

--- a/build/Dockerfile.work.rhtap
+++ b/build/Dockerfile.work.rhtap
@@ -8,6 +8,7 @@ RUN GO_BUILD_PACKAGES=./cmd/work make build --warn-undefined-variables
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/ocm" \
       name="multicluster-engine/work-rhel9" \
       summary="work" \
       description="work" \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** addon-manager, placement, registration, registration-operator, work

**Branch details:** addon-manager (branch: backplane-2.10); placement (branch: backplane-2.10); registration (branch: backplane-2.10); registration-operator (branch: backplane-2.10); work (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/ocm

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.

## Related issue(s)

Fixes #