### PR TITLE
ACM-33066: Add service-CA certificate support for PlacementDebugServer

### DIFF
--- a/manifests/cluster-manager/management/placement/deployment.yaml
+++ b/manifests/cluster-manager/management/placement/deployment.yaml
@@ -171,10 +171,22 @@ spec:
         volumeMounts:
         - name: tmpdir
           mountPath: /tmp
+        {{- if .ServingCertSecret }}
+        - name: serving-cert
+          mountPath: /var/run/secrets/serving-cert
+          readOnly: true
+        {{- end }}
       {{ end }}
       volumes:
       - name: tmpdir
         emptyDir: { }
+      {{- if .ServingCertSecret }}
+      - name: serving-cert
+        secret:
+          secretName: {{ .ServingCertSecret }}
+          defaultMode: 420
+          optional: true
+      {{- end }}
       {{ if .HostedMode }}
       - name: kubeconfig
         secret:

--- a/manifests/cluster-manager/management/placement/deployment.yaml
+++ b/manifests/cluster-manager/management/placement/deployment.yaml
@@ -171,7 +171,7 @@ spec:
         volumeMounts:
         - name: tmpdir
           mountPath: /tmp
-        {{- if .ServingCertSecret }}
+        {{- if .PlacementServingCertSecret }}
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
           readOnly: true
@@ -180,10 +180,10 @@ spec:
       volumes:
       - name: tmpdir
         emptyDir: { }
-      {{- if .ServingCertSecret }}
+      {{- if .PlacementServingCertSecret }}
       - name: serving-cert
         secret:
-          secretName: {{ .ServingCertSecret }}
+          secretName: {{ .PlacementServingCertSecret }}
           defaultMode: 420
           optional: true
       {{- end }}

--- a/manifests/cluster-manager/management/placement/service.yaml
+++ b/manifests/cluster-manager/management/placement/service.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 metadata:
   name: {{ .ClusterManagerName }}-placement
   namespace: {{ .ClusterManagerNamespace }}
+  {{ if gt (len .Annotations) 0 }}
+  annotations:
+    {{ range $key, $value := .Annotations }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+  {{ end }}
   labels:
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}

--- a/manifests/cluster-manager/management/placement/service.yaml
+++ b/manifests/cluster-manager/management/placement/service.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 metadata:
   name: {{ .ClusterManagerName }}-placement
   namespace: {{ .ClusterManagerNamespace }}
-  {{ if gt (len .Annotations) 0 }}
+  {{ if gt (len .PlacementAnnotations) 0 }}
   annotations:
-    {{ range $key, $value := .Annotations }}
+    {{ range $key, $value := .PlacementAnnotations }}
     "{{ $key }}": "{{ $value }}"
     {{ end }}
   {{ end }}

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -14,6 +14,8 @@ type HubConfig struct {
 	WorkAPIServiceCABundle         string
 	PlacementImage                 string
 	PlacementDebugServerEnabled    bool
+	ServingCertSecret              string
+	Annotations                    map[string]string
 	AddonAPIServiceCABundle        string
 	Replica                        int32
 	HostedMode                     bool

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -14,8 +14,8 @@ type HubConfig struct {
 	WorkAPIServiceCABundle         string
 	PlacementImage                 string
 	PlacementDebugServerEnabled    bool
-	ServingCertSecret              string
-	Annotations                    map[string]string
+	PlacementServingCertSecret     string
+	PlacementAnnotations           map[string]string
 	AddonAPIServiceCABundle        string
 	Replica                        int32
 	HostedMode                     bool

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -227,6 +227,13 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	}
 	_, placementFeatureMsgs = helpers.ConvertToFeatureGateFlags("Placement", placementFeatureGates, ocmfeature.DefaultHubPlacementFeatureGates)
 	config.PlacementDebugServerEnabled = helpers.FeatureGateEnabled(placementFeatureGates, ocmfeature.DefaultHubPlacementFeatureGates, ocmfeature.PlacementDebugServer)
+	if config.PlacementDebugServerEnabled {
+		secretName := config.ClusterManagerName + "-placement-serving-cert"
+		config.ServingCertSecret = secretName
+		config.Annotations = map[string]string{
+			"service.beta.openshift.io/serving-cert-secret-name": secretName,
+		}
+	}
 
 	featureGateCondition := helpers.BuildFeatureCondition(registrationFeatureMsgs, workFeatureMsgs, addonFeatureMsgs, placementFeatureMsgs)
 

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -229,8 +229,8 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	config.PlacementDebugServerEnabled = helpers.FeatureGateEnabled(placementFeatureGates, ocmfeature.DefaultHubPlacementFeatureGates, ocmfeature.PlacementDebugServer)
 	if config.PlacementDebugServerEnabled {
 		secretName := config.ClusterManagerName + "-placement-serving-cert"
-		config.ServingCertSecret = secretName
-		config.Annotations = map[string]string{
+		config.PlacementServingCertSecret = secretName
+		config.PlacementAnnotations = map[string]string{
 			"service.beta.openshift.io/serving-cert-secret-name": secretName,
 		}
 	}


### PR DESCRIPTION
## Summary

- When the PlacementDebugServer feature gate is enabled, the ClusterManager controller now injects a `service.beta.openshift.io/serving-cert-secret-name` annotation into the placement service via a generic `Annotations` map on `HubConfig` (mirrors the existing `.Labels` pattern)
- The resulting TLS secret is mounted into the debug-server container at `/var/run/secrets/serving-cert/` with `optional: true` for platform safety
- On OpenShift, the service-serving-cert controller creates a CA-signed certificate automatically; library-go detects and uses it
- On non-OpenShift, `optional: true` allows the pod to start and library-go falls back to self-signed certificates
- No changes to the placement binary — library-go's `hasServiceServingCerts()` already handles cert detection at this path

## Files Changed

| File | Change |
|------|--------|
| `manifests/config.go` | Added `Annotations map[string]string` and `ServingCertSecret string` to `HubConfig` |
| `manifests/.../placement/service.yaml` | Generic `.Annotations` range loop |
| `manifests/.../placement/deployment.yaml` | Conditional cert volume mount with `optional: true` |
| `pkg/.../clustermanager_controller.go` | Populates both fields when `PlacementDebugServerEnabled` is true |

## Test plan

- [x] Built registration-operator image with changes
- [x] Deployed to ACM 2.17.0 cluster, enabled PlacementDebugServer feature gate
- [x] Verified service annotation applied automatically by operator (not manually)
- [x] Verified OpenShift created TLS secret signed by service CA
- [x] Verified debug-server container mounts cert at `/var/run/secrets/serving-cert`
- [x] Verified debug server logs: `"Using service-serving-cert provided certificates"`
- [x] Verified console backend connects via `getServiceAgent()` without TLS errors
- [x] End-to-end validation: placement debug UI functional through in-cluster service path

🤖 Generated with [Claude Code](https://claude.com/claude-code)