### PR TITLE
:seedling: chore: reconfigure builds for versioning

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,13 +1,11 @@
 approvers:
-- zhujian7
-- zhiweiyin318
-- haoqing0110
-- elgnay
-- xuezhaojun
+- dhaiducek
+- mikeshng
+- rokej
+- tesshuflower
 
 reviewers:
-- zhujian7
-- zhiweiyin318
-- haoqing0110
-- elgnay
-- xuezhaojun
+- dhaiducek
+- mikeshng
+- rokej
+- tesshuflower

--- a/.tekton/addon-manager-mce-217-pull-request.yaml
+++ b/.tekton/addon-manager-mce-217-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/addon-manager-mce-217-push.yaml
+++ b/.tekton/addon-manager-mce-217-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/addon-manager-mce-217-push.yaml
+++ b/.tekton/addon-manager-mce-217-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-217:{{revision}}
   - name: build-platforms

--- a/.tekton/addon-manager-mce-50-pull-request.yaml
+++ b/.tekton/addon-manager-mce-50-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/addon-manager-mce-50-push.yaml
+++ b/.tekton/addon-manager-mce-50-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-50:{{revision}}
   - name: build-platforms

--- a/.tekton/addon-manager-mce-50-push.yaml
+++ b/.tekton/addon-manager-mce-50-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/addon-manager-mce-51-pull-request.yaml
+++ b/.tekton/addon-manager-mce-51-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/addon-manager-mce-51-push.yaml
+++ b/.tekton/addon-manager-mce-51-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/addon-manager-mce-51:{{revision}}
   - name: build-platforms

--- a/.tekton/addon-manager-mce-51-push.yaml
+++ b/.tekton/addon-manager-mce-51-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/placement-mce-217-pull-request.yaml
+++ b/.tekton/placement-mce-217-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/placement-mce-217-push.yaml
+++ b/.tekton/placement-mce-217-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/placement-mce-217-push.yaml
+++ b/.tekton/placement-mce-217-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-217:{{revision}}
   - name: build-platforms

--- a/.tekton/placement-mce-50-pull-request.yaml
+++ b/.tekton/placement-mce-50-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/placement-mce-50-push.yaml
+++ b/.tekton/placement-mce-50-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/placement-mce-50-push.yaml
+++ b/.tekton/placement-mce-50-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-50:{{revision}}
   - name: build-platforms

--- a/.tekton/placement-mce-51-pull-request.yaml
+++ b/.tekton/placement-mce-51-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/placement-mce-51-push.yaml
+++ b/.tekton/placement-mce-51-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/placement-mce-51-push.yaml
+++ b/.tekton/placement-mce-51-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/placement-mce-51:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-mce-217-pull-request.yaml
+++ b/.tekton/registration-mce-217-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-mce-217-push.yaml
+++ b/.tekton/registration-mce-217-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-217:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-mce-217-push.yaml
+++ b/.tekton/registration-mce-217-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-mce-50-pull-request.yaml
+++ b/.tekton/registration-mce-50-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-mce-50-push.yaml
+++ b/.tekton/registration-mce-50-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-50:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-mce-50-push.yaml
+++ b/.tekton/registration-mce-50-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-mce-51-pull-request.yaml
+++ b/.tekton/registration-mce-51-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-mce-51-push.yaml
+++ b/.tekton/registration-mce-51-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-mce-51-push.yaml
+++ b/.tekton/registration-mce-51-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-51:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-operator-mce-217-pull-request.yaml
+++ b/.tekton/registration-operator-mce-217-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-operator-mce-217-push.yaml
+++ b/.tekton/registration-operator-mce-217-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-217:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-operator-mce-217-push.yaml
+++ b/.tekton/registration-operator-mce-217-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-operator-mce-50-pull-request.yaml
+++ b/.tekton/registration-operator-mce-50-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-operator-mce-50-push.yaml
+++ b/.tekton/registration-operator-mce-50-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-operator-mce-50-push.yaml
+++ b/.tekton/registration-operator-mce-50-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-50:{{revision}}
   - name: build-platforms

--- a/.tekton/registration-operator-mce-51-pull-request.yaml
+++ b/.tekton/registration-operator-mce-51-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/registration-operator-mce-51-push.yaml
+++ b/.tekton/registration-operator-mce-51-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/registration-operator-mce-51-push.yaml
+++ b/.tekton/registration-operator-mce-51-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-operator-mce-51:{{revision}}
   - name: build-platforms

--- a/.tekton/work-mce-217-pull-request.yaml
+++ b/.tekton/work-mce-217-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/work-mce-217-push.yaml
+++ b/.tekton/work-mce-217-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-217:{{revision}}
   - name: build-platforms

--- a/.tekton/work-mce-217-push.yaml
+++ b/.tekton/work-mce-217-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/work-mce-50-pull-request.yaml
+++ b/.tekton/work-mce-50-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/work-mce-50-push.yaml
+++ b/.tekton/work-mce-50-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-50:{{revision}}
   - name: build-platforms

--- a/.tekton/work-mce-50-push.yaml
+++ b/.tekton/work-mce-50-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name

--- a/.tekton/work-mce-51-pull-request.yaml
+++ b/.tekton/work-mce-51-pull-request.yaml
@@ -29,13 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/work-mce-51-push.yaml
+++ b/.tekton/work-mce-51-push.yaml
@@ -21,6 +21,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: fetchTags
+    value: 'true'
+  - name: depth
+    value: '0'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-51:{{revision}}
   - name: build-platforms

--- a/.tekton/work-mce-51-push.yaml
+++ b/.tekton/work-mce-51-push.yaml
@@ -31,8 +31,6 @@ spec:
     - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
-  - name: path-context
-    value: .
   - name: send-slack-notification
     value: 'true'
   - name: konflux-application-name


### PR DESCRIPTION
Add `depth=0` and tag fetch so the build can pick up the proper versioning from tags.

ref: https://redhat.atlassian.net/browse/ACM-33396

Also updates pipeline parameters:

- Multi-arch PR builds aren't necessary
- path-context has . as a default value