### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/build/Dockerfile.addon.rhtap
+++ b/build/Dockerfile.addon.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/addon make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_PACKAGES=./cmd/addon make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
## Summary
- Add `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` to `make build` command in `build/Dockerfile.addon.rhtap` for FIPS compliance

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)