### PR TITLE
[Backplane 2.11] addon examples v1.2.0, only build on x86 for PRs

### DIFF
--- a/.tekton/addon-manager-mce-211-pull-request.yaml
+++ b/.tekton/addon-manager-mce-211-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.addon.rhtap
   - name: path-context

--- a/.tekton/placement-mce-211-pull-request.yaml
+++ b/.tekton/placement-mce-211-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.placement.rhtap
   - name: path-context

--- a/.tekton/registration-mce-211-pull-request.yaml
+++ b/.tekton/registration-mce-211-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration.rhtap
   - name: path-context

--- a/.tekton/registration-operator-mce-211-pull-request.yaml
+++ b/.tekton/registration-operator-mce-211-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.registration-operator.rhtap
   - name: path-context

--- a/.tekton/work-mce-211-pull-request.yaml
+++ b/.tekton/work-mce-211-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.work.rhtap
   - name: path-context

--- a/hack/e2e_flaky_error_test.sh
+++ b/hack/e2e_flaky_error_test.sh
@@ -34,8 +34,8 @@ do
     kind load docker-image --name=e2e quay.io/open-cluster-management/addon-manager:$IMAGE_TAG
 
     # This is for addon-manager test: /workspaces/OCM/test/e2e/manifests/addon/addon_template.yaml
-    docker pull quay.io/open-cluster-management/addon-examples:latest
-    kind load docker-image --name=e2e quay.io/open-cluster-management/addon-examples:latest
+    docker pull "$(cat test/e2e/ADDON_EXAMPLE_IMAGE)"
+    kind load docker-image --name=e2e "$(cat test/e2e/ADDON_EXAMPLE_IMAGE)"
 
     kind get kubeconfig --name=e2e > .kubeconfig
 

--- a/test/e2e/ADDON_EXAMPLE_IMAGE
+++ b/test/e2e/ADDON_EXAMPLE_IMAGE
@@ -1,0 +1,1 @@
+quay.io/open-cluster-management/addon-examples:v1.2.0

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -47,9 +47,11 @@ const (
 )
 
 var (
-	nodeSelector = map[string]string{"kubernetes.io/os": "linux"}
-	tolerations  = []corev1.Toleration{{Key: "foo", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}}
-	registries   = []addonapiv1alpha1.ImageMirror{
+	//go:embed ADDON_EXAMPLE_IMAGE
+	addonExampleImage embed.FS
+	nodeSelector      = map[string]string{"kubernetes.io/os": "linux"}
+	tolerations       = []corev1.Toleration{{Key: "foo", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}}
+	registries        = []addonapiv1alpha1.ImageMirror{
 		{
 			Source: "quay.io/open-cluster-management/addon-examples",
 			Mirror: "quay.io/ocm/addon-examples",
@@ -74,6 +76,8 @@ var (
 )
 
 var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, ginkgo.Label("addon-manager"), func() {
+	addonExampleImageBytes, _ := addonExampleImage.ReadFile("ADDON_EXAMPLE_IMAGE")
+	addonExampleImage := string(addonExampleImageBytes)
 	addOnName := "hello-template"
 	addonInstallNamespace := "test-addon-template"
 
@@ -120,6 +124,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,
@@ -177,6 +182,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,
@@ -482,7 +488,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != originalImageValue {
+			if containers[0].Image != addonExampleImage {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 
@@ -672,7 +678,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != originalImageValue {
+			if containers[0].Image != addonExampleImage {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 

--- a/test/e2e/manifests/addon/addon_template.yaml
+++ b/test/e2e/manifests/addon/addon_template.yaml
@@ -40,7 +40,7 @@ spec:
                   serviceAccountName: hello-template-agent-sa
                   containers:
                     - name: helloworld-agent
-                      image: quay.io/open-cluster-management/addon-examples:latest
+                      image: << AddonExampleImage >>
                       imagePullPolicy: IfNotPresent
                       args:
                         - "/helloworld_helm"
@@ -124,7 +124,7 @@ spec:
                   restartPolicy: Never
                   containers:
                   - name: hello-template-agent
-                    image: quay.io/open-cluster-management/addon-examples:latest
+                    image: << AddonExampleImage >>
                     imagePullPolicy: IfNotPresent
                     args:
                       - "/helloworld_helm"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- build on x86 only for PRs in konflux
- use v1.2.0 addon-examples to avoid issues with examples expecting v1beta1 addon apis when this older version of OCM is serving v1alpha1 only

## Related issue(s)

Fixes #