### PR TITLE
Add FIPS build flags to remaining RHTAP Dockerfiles

### DIFF
--- a/build/Dockerfile.placement.rhtap
+++ b/build/Dockerfile.placement.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/placement make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_PACKAGES=./cmd/placement make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -8,7 +8,7 @@ ARG MCE_VERSION
 ENV SOURCE_GIT_TAG=${MCE_VERSION}
 RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
-RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.registration.rhtap
+++ b/build/Dockerfile.registration.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/registration make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_PACKAGES=./cmd/registration make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.work.rhtap
+++ b/build/Dockerfile.work.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/work make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_PACKAGES=./cmd/work make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Apply CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to work, registration, registration-operator, and placement Konflux builds.

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com/)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #