### PR TITLE
fix: preserve config reference ordering in cmainstallprogression controller (backport to backplane-2.17)

### DIFF
--- a/pkg/addon/controllers/cmainstallprogression/controller.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -130,10 +129,10 @@ func setInstallProgression(supportedConfigs []addonv1alpha1.ConfigMeta, placemen
 		}
 
 		// set config references as default configuration
-		installConfigReferencesMap := map[addonv1alpha1.ConfigGroupResource]sets.Set[addonv1alpha1.ConfigReferent]{}
+		installConfigReferencesMap := map[addonv1alpha1.ConfigGroupResource][]addonv1alpha1.ConfigReferent{}
 		for _, config := range supportedConfigs {
 			if config.DefaultConfig != nil {
-				installConfigReferencesMap[config.ConfigGroupResource] = sets.New[addonv1alpha1.ConfigReferent](*config.DefaultConfig)
+				installConfigReferencesMap[config.ConfigGroupResource] = []addonv1alpha1.ConfigReferent{*config.DefaultConfig}
 			}
 		}
 
@@ -156,7 +155,7 @@ func setInstallProgression(supportedConfigs []addonv1alpha1.ConfigMeta, placemen
 		installConfigReferences := []addonv1alpha1.InstallConfigReference{}
 		for _, gvk := range gvks {
 			if configRefs, ok := installConfigReferencesMap[gvk]; ok {
-				for configRef := range configRefs {
+				for _, configRef := range configRefs {
 					installConfigReferences = append(installConfigReferences,
 						addonv1alpha1.InstallConfigReference{
 							ConfigGroupResource: gvk,
@@ -217,23 +216,37 @@ func mergeInstallProgression(newobj, oldobj *addonv1alpha1.InstallProgression) {
 }
 
 // Override the desired configs by a slice of AddOnConfig (from cma install strategy),
+// preserving the order in which configs appear in addOnConfigs and deduplicating by
+// ConfigReferent (namespace + name) within each GVK.
 func overrideConfigMapByAddOnConfigs(
-	desiredConfigs map[addonv1alpha1.ConfigGroupResource]sets.Set[addonv1alpha1.ConfigReferent],
+	desiredConfigs map[addonv1alpha1.ConfigGroupResource][]addonv1alpha1.ConfigReferent,
 	addOnConfigs []addonv1alpha1.AddOnConfig,
 ) {
-	gvkOverwritten := sets.New[addonv1alpha1.ConfigGroupResource]()
+	gvkOverwritten := map[addonv1alpha1.ConfigGroupResource]bool{}
 	// Go through the cma install strategy configs,
 	// for a group of configs with same gvk, install strategy configs override the desiredConfigs.
 	for _, config := range addOnConfigs {
 		gr := config.ConfigGroupResource
-		if !gvkOverwritten.Has(gr) {
-			desiredConfigs[gr] = sets.New[addonv1alpha1.ConfigReferent]()
-			gvkOverwritten.Insert(gr)
+		if !gvkOverwritten[gr] {
+			desiredConfigs[gr] = []addonv1alpha1.ConfigReferent{}
+			gvkOverwritten[gr] = true
 		}
-		// If a config not exist in the desiredConfigs, append it.
+		// If a config does not exist in the desiredConfigs, append it.
 		// This is to avoid adding duplicate configs (name + namespace).
-		if !desiredConfigs[gr].Has(config.ConfigReferent) {
-			desiredConfigs[gr].Insert(config.ConfigReferent)
+		if !containsConfigReferent(desiredConfigs[gr], config.ConfigReferent) {
+			desiredConfigs[gr] = append(desiredConfigs[gr], config.ConfigReferent)
 		}
 	}
+}
+
+// containsConfigReferent returns true if the given ConfigReferent exists in the slice.
+// ConfigReferent is a struct of two strings (Namespace, Name), so == performs a
+// field-by-field value comparison equivalent to r.Namespace == ref.Namespace && r.Name == ref.Name.
+func containsConfigReferent(refs []addonv1alpha1.ConfigReferent, ref addonv1alpha1.ConfigReferent) bool {
+	for _, r := range refs {
+		if r == ref {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/addon/controllers/cmainstallprogression/controller_test.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller_test.go
@@ -192,12 +192,21 @@ func TestReconcile(t *testing.T) {
 				if len(cma.Status.InstallProgressions[1].ConfigReferences) != 1 {
 					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
 				}
-				if len(cma.Status.InstallProgressions[2].ConfigReferences) != 2 {
-					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-				}
-				if len(cma.Status.InstallProgressions[3].ConfigReferences) != 1 {
-					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-				}
+			if len(cma.Status.InstallProgressions[2].ConfigReferences) != 2 {
+				t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+			}
+			// Verify ordering matches the spec order: test/test first, then test1/test
+			if cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Namespace != "test" ||
+				cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Name != "test" {
+				t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig)
+			}
+			if cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Namespace != "test1" ||
+				cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Name != "test" {
+				t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig)
+			}
+			if len(cma.Status.InstallProgressions[3].ConfigReferences) != 1 {
+				t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+			}
 			},
 		},
 		{
@@ -311,12 +320,19 @@ func TestReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].ConfigReferences[0].DesiredConfig.Name != "test1" {
 					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences[0].DesiredConfig.Name)
 				}
-				if len(cma.Status.InstallProgressions[1].ConfigReferences) != 2 {
-					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-				}
-				if len(cma.Status.InstallProgressions[2].ConfigReferences) != 3 {
-					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-				}
+			if len(cma.Status.InstallProgressions[1].ConfigReferences) != 2 {
+				t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+			}
+			// Verify ordering matches the spec order: test1 first, then test2
+			if cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig.Name != "test1" {
+				t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig)
+			}
+			if cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig.Name != "test2" {
+				t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig)
+			}
+			if len(cma.Status.InstallProgressions[2].ConfigReferences) != 3 {
+				t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+			}
 			},
 		},
 	}

--- a/pkg/addon/controllers/cmainstallprogression/controller_test.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller_test.go
@@ -192,21 +192,21 @@ func TestReconcile(t *testing.T) {
 				if len(cma.Status.InstallProgressions[1].ConfigReferences) != 1 {
 					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
 				}
-			if len(cma.Status.InstallProgressions[2].ConfigReferences) != 2 {
-				t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-			}
-			// Verify ordering matches the spec order: test/test first, then test1/test
-			if cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Namespace != "test" ||
-				cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Name != "test" {
-				t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig)
-			}
-			if cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Namespace != "test1" ||
-				cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Name != "test" {
-				t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig)
-			}
-			if len(cma.Status.InstallProgressions[3].ConfigReferences) != 1 {
-				t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-			}
+				if len(cma.Status.InstallProgressions[2].ConfigReferences) != 2 {
+					t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+				}
+				// Verify ordering matches the spec order: test/test first, then test1/test
+				if cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Namespace != "test" ||
+					cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig.Name != "test" {
+					t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[0].DesiredConfig)
+				}
+				if cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Namespace != "test1" ||
+					cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig.Name != "test" {
+					t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[2].ConfigReferences[1].DesiredConfig)
+				}
+				if len(cma.Status.InstallProgressions[3].ConfigReferences) != 1 {
+					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+				}
 			},
 		},
 		{
@@ -320,19 +320,19 @@ func TestReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].ConfigReferences[0].DesiredConfig.Name != "test1" {
 					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences[0].DesiredConfig.Name)
 				}
-			if len(cma.Status.InstallProgressions[1].ConfigReferences) != 2 {
-				t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-			}
-			// Verify ordering matches the spec order: test1 first, then test2
-			if cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig.Name != "test1" {
-				t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig)
-			}
-			if cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig.Name != "test2" {
-				t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig)
-			}
-			if len(cma.Status.InstallProgressions[2].ConfigReferences) != 3 {
-				t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
-			}
+				if len(cma.Status.InstallProgressions[1].ConfigReferences) != 2 {
+					t.Fatalf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+				}
+				// Verify ordering matches the spec order: test1 first, then test2
+				if cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig.Name != "test1" {
+					t.Errorf("InstallProgressions ConfigReferences[0] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[0].DesiredConfig)
+				}
+				if cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig.Name != "test2" {
+					t.Errorf("InstallProgressions ConfigReferences[1] ordering is not correct: %v", cma.Status.InstallProgressions[1].ConfigReferences[1].DesiredConfig)
+				}
+				if len(cma.Status.InstallProgressions[2].ConfigReferences) != 3 {
+					t.Errorf("InstallProgressions ConfigReferences object is not correct: %v", cma.Status.InstallProgressions[0].ConfigReferences)
+				}
 			},
 		},
 	}

--- a/test/integration/addon/addon_configs_test.go
+++ b/test/integration/addon/addon_configs_test.go
@@ -473,4 +473,177 @@ var _ = ginkgo.Describe("AddConfigs", func() {
 			},
 		})
 	})
+
+	ginkgo.It("Should preserve config reference ordering for multiple same-GVK configs in a placement", func() {
+		// Create two AddonDeploymentConfigs of the same GVK in the placement namespace.
+		// The ordering in the CMA placement spec should be preserved in both the CMA status
+		// InstallProgressions and the MCA status ConfigReferences.
+		config1 := &addonapiv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-first",
+				Namespace: configDefaultNamespace,
+			},
+			Spec: addOnTest1ConfigSpec,
+		}
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(configDefaultNamespace).Create(
+			context.Background(), config1, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		config2 := &addonapiv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-second",
+				Namespace: configDefaultNamespace,
+			},
+			Spec: addOnTest2ConfigSpec,
+		}
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(configDefaultNamespace).Create(
+			context.Background(), config2, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Patch CMA to use a placement strategy with 2 configs of the same GVK.
+		// The ordering config-first → config-second must be preserved.
+		cma, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(
+			context.Background(), testAddOnConfigsImpl.name, metav1.GetOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		cma.Spec.InstallStrategy = addonapiv1alpha1.InstallStrategy{
+			Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+			Placements: []addonapiv1alpha1.PlacementStrategy{
+				{
+					PlacementRef: addonapiv1alpha1.PlacementRef{
+						Name:      "test-placement",
+						Namespace: configDefaultNamespace,
+					},
+					Configs: []addonapiv1alpha1.AddOnConfig{
+						{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+								Group:    addOnDeploymentConfigGVR.Group,
+								Resource: addOnDeploymentConfigGVR.Resource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Namespace: configDefaultNamespace,
+								Name:      "config-first",
+							},
+						},
+						{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+								Group:    addOnDeploymentConfigGVR.Group,
+								Resource: addOnDeploymentConfigGVR.Resource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Namespace: configDefaultNamespace,
+								Name:      "config-second",
+							},
+						},
+					},
+					RolloutStrategy: clusterv1alpha1.RolloutStrategy{
+						Type: clusterv1alpha1.All,
+					},
+				},
+			},
+		}
+		patchClusterManagementAddOn(context.Background(), cma)
+
+		// Create placement and placement decision so the cluster is selected.
+		placement := &clusterv1beta1.Placement{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: configDefaultNamespace},
+		}
+		_, err = hubClusterClient.ClusterV1beta1().Placements(configDefaultNamespace).Create(
+			context.Background(), placement, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		decision := &clusterv1beta1.PlacementDecision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-placement",
+				Namespace: configDefaultNamespace,
+				Labels: map[string]string{
+					clusterv1beta1.PlacementLabel:          "test-placement",
+					clusterv1beta1.DecisionGroupIndexLabel: "0",
+				},
+			},
+		}
+		decision, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(configDefaultNamespace).Create(
+			context.Background(), decision, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		decision.Status.Decisions = []clusterv1beta1.ClusterDecision{
+			{ClusterName: managedClusterName},
+		}
+		_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(configDefaultNamespace).UpdateStatus(
+			context.Background(), decision, metav1.UpdateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// CMA status: InstallProgressions should have both configs in spec order (config-first → config-second).
+		assertClusterManagementAddOnInstallProgression(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+			PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement", Namespace: configDefaultNamespace},
+			ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    addOnDeploymentConfigGVR.Group,
+						Resource: addOnDeploymentConfigGVR.Resource,
+					},
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      "config-first",
+						},
+						SpecHash: addOnTest1ConfigSpecHash,
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    addOnDeploymentConfigGVR.Group,
+						Resource: addOnDeploymentConfigGVR.Resource,
+					},
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      "config-second",
+						},
+						SpecHash: addOnTest2ConfigSpecHash,
+					},
+				},
+			},
+		})
+
+		// MCA status: ConfigReferences should reflect the same order (config-first → config-second).
+		assertManagedClusterAddOnConfigReferences(testAddOnConfigsImpl.name, managedClusterName,
+			addonapiv1alpha1.ConfigReference{
+				ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+					Group:    addOnDeploymentConfigGVR.Group,
+					Resource: addOnDeploymentConfigGVR.Resource,
+				},
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: configDefaultNamespace,
+					Name:      "config-first",
+				},
+				LastObservedGeneration: 1,
+				DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      "config-first",
+					},
+					SpecHash: addOnTest1ConfigSpecHash,
+				},
+			},
+			addonapiv1alpha1.ConfigReference{
+				ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+					Group:    addOnDeploymentConfigGVR.Group,
+					Resource: addOnDeploymentConfigGVR.Resource,
+				},
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
+					Namespace: configDefaultNamespace,
+					Name:      "config-second",
+				},
+				LastObservedGeneration: 1,
+				DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      "config-second",
+					},
+					SpecHash: addOnTest2ConfigSpecHash,
+				},
+			},
+		)
+	})
 })


### PR DESCRIPTION
Backport of upstream fix [open-cluster-management-io/ocm#1610](https://github.com/open-cluster-management-io/ocm/pull/1610) (merged as open-cluster-management-io/ocm@8a96e8e0a) to backplane-2.17.

Fixes: https://issues.redhat.com/browse/ACM-36433

## Problem

The `cmaInstallProgressionController` uses a `sets.Set[ConfigReferent]` (a Go map) to collect per-placement configs. When a placement has multiple configs of the same GVK, iterating the set produces a random order on each reconcile, causing status thrashing and nondeterministic config consumption.

## Solution

Replace `sets.Set[ConfigReferent]` with `[]ConfigReferent` and a manual dedup check, preserving the spec-defined insertion order from the CMA placement configs.

## Changes

- `pkg/addon/controllers/cmainstallprogression/controller.go` — replace set with slice+dedup
- `pkg/addon/controllers/cmainstallprogression/controller_test.go` — add ordering assertions
- `test/integration/addon/addon_configs_test.go` — integration test for full pipeline ordering