### PR TITLE
:sparkles: feat: ACM-30622: add NetworkPolicies for open-cluster-management-agent namespace

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
@@ -69,5 +69,8 @@ rules:
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
   verbs: ["list", "update", "patch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]
 {{- end }}
 {{- end }}

--- a/deploy/klusterlet/config/rbac/cluster_role.yaml
+++ b/deploy/klusterlet/config/rbac/cluster_role.yaml
@@ -69,3 +69,6 @@ rules:
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
   verbs: ["list", "update", "patch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]

--- a/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: klusterlet-agent
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: klusterlet-agent
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: open-cluster-management-hub
+    ports:
+    - protocol: TCP
+      port: 9443
+  - to:
+    - podSelector: {}

--- a/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-and-api
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443

--- a/manifests/klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: klusterlet
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: klusterlet
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector: {}
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          addon.open-cluster-management.io/namespace: "true"
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -17,6 +17,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -148,6 +149,8 @@ func CleanUpStaticObject(
 		err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
 	case *admissionv1.MutatingWebhookConfiguration:
 		err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
+	case *networkingv1.NetworkPolicy:
+		err = client.NetworkingV1().NetworkPolicies(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{})
 	default:
 		err = fmt.Errorf("unhandled type %T", object)
 	}
@@ -503,6 +506,8 @@ func GenerateRelatedResource(objBytes []byte) (operatorapiv1.RelatedResourceMeta
 		relatedResource = newRelatedResource(rbacv1.SchemeGroupVersion.WithResource("rolebindings"), requiredObj)
 	case *apiextensionsv1.CustomResourceDefinition:
 		relatedResource = newRelatedResource(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), requiredObj)
+	case *networkingv1.NetworkPolicy:
+		relatedResource = newRelatedResource(networkingv1.SchemeGroupVersion.WithResource("networkpolicies"), requiredObj)
 	default:
 		return relatedResource, fmt.Errorf("unhandled type %T", requiredObj)
 	}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
@@ -50,9 +50,9 @@ func TestSyncDelete(t *testing.T) {
 		}
 	}
 
-	// 11 managed static manifests + 12 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
-	if len(deleteActions) != 28 {
-		t.Errorf("Expected 28 delete actions, but got %d", len(deleteActions))
+	// 11 managed static manifests + 16 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
+	if len(deleteActions) != 32 {
+		t.Errorf("Expected 32 delete actions, but got %d", len(deleteActions))
 	}
 
 	var updateWorkActions []clienttesting.PatchActionImpl
@@ -108,10 +108,10 @@ func TestSyncDeleteHosted(t *testing.T) {
 		}
 	}
 
-	// 11 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
+	// 15 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
 	// + 2 deployments(registration-agent,work-agent) + 1 namespace
-	if len(deleteActionsManagement) != 17 {
-		t.Errorf("Expected 17 delete actions, but got %d", len(deleteActionsManagement))
+	if len(deleteActionsManagement) != 21 {
+		t.Errorf("Expected 21 delete actions, but got %d", len(deleteActionsManagement))
 	}
 
 	var deleteActionsManaged []clienttesting.DeleteActionImpl

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -627,9 +627,9 @@ func TestSyncDeploy(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 11 managed static manifests + 12 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
-			if len(createObjects) != 24 {
-				t.Errorf("Expect 24 objects created in the sync loop, actual %d", len(createObjects))
+			// 11 managed static manifests + 16 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
+			if len(createObjects) != 28 {
+				t.Errorf("Expect 28 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -709,9 +709,9 @@ func TestSyncDeploySingleton(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 10 managed static manifests + 11 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
-			if len(createObjects) != 22 {
-				t.Errorf("Expect 21 objects created in the sync loop, actual %d", len(createObjects))
+			// 10 managed static manifests + 15 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
+			if len(createObjects) != 26 {
+				t.Errorf("Expect 26 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -781,10 +781,10 @@ func TestSyncDeployHosted(t *testing.T) {
 		}
 	}
 	// Check if resources are created as expected on the management cluster
-	// 11 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
+	// 15 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
 	// 2 deployments(registration-agent,work-agent) + 1 pull secret
-	if len(createObjectsManagement) != 16 {
-		t.Errorf("Expect 16 objects created in the sync loop, actual %d", len(createObjectsManagement))
+	if len(createObjectsManagement) != 20 {
+		t.Errorf("Expect 20 objects created in the sync loop, actual %d", len(createObjectsManagement))
 	}
 	for _, object := range createObjectsManagement {
 		ensureObject(t, object, klusterlet, false)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
@@ -36,6 +36,10 @@ var (
 		"klusterlet/management/klusterlet-work-role.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding-extension-apiserver.yaml",
+		"klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-agent-networkpolicy.yaml",
 	}
 )
 


### PR DESCRIPTION
 ## Summary

  Ship 4 NetworkPolicy manifests with the klusterlet operator to restrict
  ingress/egress in the `open-cluster-management-agent` namespace, meeting CIS Kube
  benchmark 5.3.2 and OCPSTRAT-819 requirements.

  ### Policies added

  | Policy | Purpose |
  |--------|---------|
  | `default-deny-all` | Baseline deny for all ingress and egress |
  | `allow-dns-and-api` | DNS egress (OpenShift DNS on 5353, kube-dns on 53) +
  ports-only API server egress (TCP 443/6443) |
  | `klusterlet` | Operator egress to intra-namespace pods, addon namespaces, and
  `kubernetes.default.svc` |
  | `klusterlet-agent` | Agent egress to `kubernetes.default.svc`, hub webhooks
  (port 9443), and intra-namespace pods |

  ### Other changes

  - **RBAC**: Added `networking.k8s.io/networkpolicies` permissions to the
  klusterlet ClusterRole (both static and Helm chart)
  - **Cleanup**: Added `*networkingv1.NetworkPolicy` case to `CleanUpStaticObject`
  and `GenerateRelatedResource` in `helpers.go`
  - **Static resource registration**: Added 4 NP file paths to
  `managementStaticResourceFiles` in the management reconciler
  - **Tests**: Updated action counts in `TestSyncDeploy`, `TestSyncDeploySingleton`,
  `TestSyncDeployHosted`, `TestSyncDelete`, and `TestSyncDeleteHosted`

  ### Design decisions

  - **Ports-only egress (no `to` selector) for API server access**: The
  `allow-dns-and-api` policy uses ports-only rules for TCP 443/6443 without
  restricting destination IPs or hostnames. This ensures the policy works on both
  hub (local-cluster) and spoke clusters without needing to know the hub API server
  address, and avoids breakage from cloud load balancer IP rotation.
  - **Follows existing static resource pattern**: NPs are embedded via `//go:embed`,
  templated with `{{ .AgentNamespace }}`, and applied via `ApplyDirectly()` /
  `ApplyNetworkPolicy()` — consistent with how all other management static resources
  are handled.
  - **Works across all deploy modes**: Singleton (combined `klusterlet-agent`),
  Default (separate registration/work agents), and Hosted modes are all covered by
  the pod selector labels used in each policy.

  ### Testing

  - **Hub cluster (local-cluster)**: Custom operator image deployed, all 4 NPs
  created automatically via reconciliation, all pods healthy, zero errors
  - **Spoke cluster**: NPs applied manually (same YAML), verified all agents
  maintained hub connectivity (`HubConnectionDegraded: False`), zero network errors
  in logs
  - **Unit tests**: All updated test counts pass