### PR TITLE
CVE-2026-27145: bump go directive to 1.26.4 on backplane-2.8

### DIFF
--- a/.github/workflows/cloudevents-integration.yml
+++ b/.github/workflows/cloudevents-integration.yml
@@ -11,7 +11,7 @@ on:
       - release-*
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
       - release-*
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   USE_EXISTING_CLUSTER: false # set to true to use an existing kind cluster for debugging with act
 
@@ -34,7 +34,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
         with:
           version: v0.22.0
           skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
@@ -72,7 +72,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
         with:
           version: v0.22.0
           skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
@@ -110,7 +110,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
         with:
           version: v0.22.0
           skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -13,7 +13,7 @@ on:
       - release-*
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/ocm/ocm/go'
   GITHUB_REF: ${{ github.ref }}

--- a/build/Dockerfile.addon
+++ b/build/Dockerfile.addon
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.addon.rhtap
+++ b/build/Dockerfile.addon.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm

--- a/build/Dockerfile.placement
+++ b/build/Dockerfile.placement
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.placement.rhtap
+++ b/build/Dockerfile.placement.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm

--- a/build/Dockerfile.registration
+++ b/build/Dockerfile.registration
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.registration-operator
+++ b/build/Dockerfile.registration-operator
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm

--- a/build/Dockerfile.registration.rhtap
+++ b/build/Dockerfile.registration.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm

--- a/build/Dockerfile.work
+++ b/build/Dockerfile.work
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.work.rhtap
+++ b/build/Dockerfile.work.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/ocm
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.35.0

--- a/pkg/placement/controllers/scheduling/scheduling_controller.go
+++ b/pkg/placement/controllers/scheduling/scheduling_controller.go
@@ -676,7 +676,7 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 	clusterDecisions := placementDecision.Status.Decisions
 
 	if len(clusterDecisions) > maxNumOfClusterDecisions {
-		return fmt.Errorf("the number of clusterdecisions %q exceeds the max limitation %q", len(clusterDecisions), maxNumOfClusterDecisions)
+		return fmt.Errorf("the number of clusterdecisions %d exceeds the max limitation %d", len(clusterDecisions), maxNumOfClusterDecisions)
 	}
 
 	existPlacementDecision, err := c.placementDecisionLister.PlacementDecisions(placementDecision.Namespace).Get(placementDecisionName)


### PR DESCRIPTION
## CVE
CVE-2026-27145 — golang crypto/x509: Denial of Service via excessive processing of DNS SAN entries

Also remediates:
- CVE-2026-39825 — net/http/httputil: ReverseProxy forwards hidden query parameters (fixed in Go 1.26.3+)

## Jira
- https://redhat.atlassian.net/browse/ACM-37650
- https://redhat.atlassian.net/browse/ACM-37671
- https://redhat.atlassian.net/browse/ACM-37678
- https://redhat.atlassian.net/browse/ACM-37686
- https://redhat.atlassian.net/browse/ACM-37693

## Summary
Bump `go` directive in `go.mod` from `1.25.0` to `1.26.4`, official Dockerfiles to `golang:1.26-bookworm`, and RHTAP builder images from `openshift-golang-builder:rhel_9_1.25` to `rhel_9_1.26`.

CI uses `stolostron/builder:go1.26-linux`. A `go 1.25.x` directive selects golangci-lint built for Go 1.25, which panics under the Go 1.26 toolchain — so **1.26.4 is required** (not 1.25.11).

Per [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037), CVE-2026-27145 is a Go **stdlib** `crypto/x509` issue fixed in **Go 1.26.4+** on the 1.26 line (not `golang.org/x/crypto`).

CVE-2026-39825 ([GO-2026-4976](https://pkg.go.dev/vuln/GO-2026-4976)) is fixed in Go 1.26.3+, so this bump covers both.

Aligned with upstream Go 1.26 upgrade ([open-cluster-management-io/ocm#1571](https://github.com/open-cluster-management-io/ocm/pull/1571)): placement printf `%q`→`%d` for Go 1.26, GHA `GO_VERSION` 1.25→1.26, and pin `engineerd/setup-kind` by commit SHA.

**Changes:**
- `go 1.25.0` → `go 1.26.4` in `go.mod`
- `build/Dockerfile.{addon,placement,registration,registration-operator,work}`: `golang:1.25-bookworm` → `golang:1.26-bookworm`
- `build/Dockerfile.*.rhtap`: `openshift-golang-builder:rhel_9_1.25` → `rhel_9_1.26`
- `pkg/placement/.../scheduling_controller.go`: fix `%q`→`%d` for clusterdecisions max limitation (Go 1.26)
- `.github/workflows/{cloudevents-integration,e2e,post,pre,releaseimage}.yml`: `GO_VERSION` 1.25→1.26; pin `setup-kind` in e2e.yml

Supersedes closed PRs:
- #796 (go 1.25.10 only)
- #797 / #798 (incorrect x/crypto bumps)

## Test plan
- [ ] CI verify / unit / images green with Go 1.26.4 directive
- [ ] golangci-lint no longer panics under builder:go1.26-linux
- [ ] Image builds succeed with `golang:1.26-bookworm`
- [ ] RHTAP/Konflux builds succeed with rhel_9_1.26 builder

Made with [Cursor](https://cursor.com)