### PR TITLE
Add cluster-manager NetworkPolicy to OLM catalog manifests

### DIFF
--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager-networkpolicy.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-manager-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: cluster-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # DNS
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443


### PR DESCRIPTION
  Add a NetworkPolicy for the registration-operator (cluster-manager) pod
  to the OLM catalog manifests so the backplane-operator chart automation
  picks it up instead of removing it.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #